### PR TITLE
Remove ext folder

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,7 +41,7 @@ install:
     - cmd: conda.exe config --add channels conda-forge
 
     # Configure the VM.
-    - cmd: conda.exe install -n root --quiet --yes conda-forge-ci-setup=2
+    - cmd: conda.exe install -n root --quiet --yes conda-forge-ci-setup=2 conda-build=3.16
     - cmd: run_conda_forge_build_setup
 
 # Skip .NET project specific build phase.

--- a/.circleci/build_steps.sh
+++ b/.circleci/build_steps.sh
@@ -19,7 +19,7 @@ conda-build:
 
 CONDARC
 
-conda install --yes --quiet conda-forge::conda-forge-ci-setup=2 conda-build
+conda install --yes --quiet conda-forge::conda-forge-ci-setup=2 conda-build=3.16
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
       echo "Configuring conda."
       source /Users/travis/miniconda3/bin/activate root
 
-      conda install --yes --quiet conda-forge::conda-forge-ci-setup=2
+      conda install --yes --quiet conda-forge::conda-forge-ci-setup=2 conda-build=3.16
       setup_conda_rc ./ ./recipe ./.ci_support/${CONFIG}.yaml
 
       source run_conda_forge_build_setup

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,1 +1,3 @@
 XCOPY "." "%LIBRARY_PREFIX%" /e
+
+rd /s /q "%LIBRARY_PREFIX%\lib\ext\"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,3 +6,5 @@ mkdir -p $target
 cp -r * $target
 cd $PREFIX/bin
 ln -s ../opt/maven/bin/* .
+
+rm -fr $target/lib/ext/


### PR DESCRIPTION
`ext` folder still persist in recent maven version and `openjdk` >=9 can't run if that folder exists (I know it's weird...).

The folder is empty anyway in the maven repo so I think it's ok to delete it.