### PR TITLE
remove openjdk upper bound limit

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,5 +1,5 @@
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,13 +10,13 @@ source:
     sha256: c035591b9238d6832c19ad6e56506631f6330ad5c53868a80fdd5eaea365a467
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
-    - openjdk <18.0.0a0
+    - openjdk
   run:
-    - openjdk <18.0.0a0
+    - openjdk
 
 test:
   commands:


### PR DESCRIPTION
Hello, I think you should remove this upper limit on the OpenJDK. From the Maven documentation, the limit is only on JDK 8,  " Maven 3.9+ requires JDK 8 or above to execute" source: https://maven.apache.org/download.cgi

why set this upper bound limit?

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
